### PR TITLE
Refactoring code to follow PEP8 conventions

### DIFF
--- a/cuba_weather/weather.py
+++ b/cuba_weather/weather.py
@@ -1,49 +1,52 @@
 #!/usr/bin/env python3
 
-import argparse
-import json
-import urllib.parse
-import urllib.request
+from argparse import ArgumentParser
+from json import loads
 from urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.request import urlopen
 
-__version__ = "0.0.2"
+__version__ = '0.0.2'
 
-API = "https://www.redcuba.cu/api/weather_get_summary/{location}"
+API = 'https://www.redcuba.cu/api/weather_get_summary/{location}'
 
 
 class RCApiClient:
-    data = False
 
     def __init__(self, location: str):
-        escaped_location = urllib.parse.quote(location)
+        escaped_location = quote(location)
         url = API.format(location=escaped_location)
-        response = urllib.request.urlopen(url)
+        response = urlopen(url)
         content = response.read()
         if type(content) == bytes:
             content = content.decode()
-        self.data = json.loads(content)
+        self.data = loads(content)
 
-    def getTemperature(self) -> str:
-        return self.data["data"]["temp"]
+    @property
+    def temperature(self) -> str:
+        return self.data['data']['temp']
 
-    def getHumidity(self) -> str:
-        return self.data["data"]["humidity"]
+    @property
+    def humidity(self) -> str:
+        return self.data['data']['humidity']
 
-    def getPressure(self) -> str:
-        return self.data["data"]["pressure"]
+    @property
+    def pressure(self) -> str:
+        return self.data['data']['pressure']
 
-    def getGeneral(self) -> str:
-        return self.data["data"]["descriptionWeather"]
+    @property
+    def general(self) -> str:
+        return self.data['data']['descriptionWeather']
 
 
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("location", type=str, help="Location name")
-    parser.add_argument("-v", "--version", help="Shows program version", action="store_true")
-    parser.add_argument("-t", "--temperature", help="Shows location temperature", action="store_true")
-    parser.add_argument("-u", "--humidity", help="Shows location humidity", action="store_true")
-    parser.add_argument("-p", "--pressure", help="Shows location pressure", action="store_true")
-    parser.add_argument("-g", "--general", help="Shows location general information", action="store_true")
+    parser = ArgumentParser()
+    parser.add_argument('location', type=str, help='Location name')
+    parser.add_argument('-v', '--version', help='Shows program version', action='store_true')
+    parser.add_argument('-t', '--temperature', help='Shows location temperature', action='store_true')
+    parser.add_argument('-u', '--humidity', help='Shows location humidity', action='store_true')
+    parser.add_argument('-p', '--pressure', help='Shows location pressure', action='store_true')
+    parser.add_argument('-g', '--general', help='Shows location general information', action='store_true')
 
     args = parser.parse_args()
 
@@ -51,7 +54,7 @@ def main():
         c = RCApiClient(args.location)
     except HTTPError as ex:
         if ex.code == 404:
-            print("Location not found, try checking your orthography or use a near by location.")
+            print('Location not found, try checking your orthography or use a near by location.')
         else:
             raise Exception(ex)
         return
@@ -59,27 +62,20 @@ def main():
     if args.version:
         print(__version__)
     if args.general:
-        print(c.getGeneral())
+        print(c.general)
     if args.temperature:
-        print("Temperature: {temp}°C".format(temp=c.getTemperature()))
+        print('Temperature: {temp}°C'.format(temp=c.temperature))
     if args.humidity:
-        print("Humidity: {hum}%".format(hum=c.getHumidity()))
+        print('Humidity: {hum}%'.format(hum=c.humidity))
     if args.pressure:
-        print("Pressure: {hpa} hpa".format(hpa=c.getPressure()))
+        print('Pressure: {hpa} hpa'.format(hpa=c.pressure))
 
-    if (
-        args.location
-        and args.version == False
-        and args.temperature == False
-        and args.humidity == False
-        and args.pressure == False
-        and args.general == False
-    ):
-        print(c.getGeneral())
-        print("Temperature: {temp}°C".format(temp=c.getTemperature()))
-        print("Humidity: {hum}%".format(hum=c.getHumidity()))
-        print("Pressure: {hpa} hpa".format(hpa=c.getPressure()))
+    if args.location and not any([args.version, args.temperature, args.humidity, args.pressure, args.general]):
+        print(c.general)
+        print('Temperature: {temp}°C'.format(temp=c.temperature))
+        print('Humidity: {hum}%'.format(hum=c.humidity))
+        print('Pressure: {hpa} hpa'.format(hpa=c.pressure))
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/cuba_weather/weather.py
+++ b/cuba_weather/weather.py
@@ -6,7 +6,7 @@ from urllib.error import HTTPError
 from urllib.parse import quote
 from urllib.request import urlopen
 
-__version__ = '0.0.2'
+__version__ = '0.0.3'
 
 API = 'https://www.redcuba.cu/api/weather_get_summary/{location}'
 

--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,29 @@
 from setuptools import setup, find_packages
 from distutils.util import convert_path
 
-with open("README.md", "r") as fh:
+with open('README.md', 'r') as fh:
     long_description = fh.read()
 
 main_ns = {}
-ver_path = convert_path("cuba_weather/weather.py")
+ver_path = convert_path('cuba_weather/weather.py')
 with open(ver_path) as ver_file:
     exec(ver_file.read(), main_ns)
 
 setup(
-    name="cuba_weather",
-    version=main_ns["__version__"],
+    name='cuba_weather',
+    version=main_ns['__version__'],
     packages=find_packages(),
-    entry_points={"console_scripts": ["cuba-weather=cuba_weather.weather:main"],},
-    url="https://github.com/daxslab/cuba-weather",
-    license="MIT",
-    author="Cuban Open Source Community",
-    description="Python3 client for (https://www.redcuba.cu) weather API",
+    entry_points={'console_scripts': ['cuba-weather=cuba_weather.weather:main'],},
+    url='https://github.com/daxslab/cuba-weather',
+    license='MIT',
+    author='Cuban Open Source Community',
+    description='Python3 client for (https://www.redcuba.cu) weather API',
     long_description=long_description,
-    long_description_content_type="text/markdown",
+    long_description_content_type='text/markdown',
     classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
+        'Programming Language :: Python :: 3',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
     ],
-    python_requires=">=3.6",
+    python_requires='>=3.6',
 )


### PR DESCRIPTION
1. Rename the methods of the class to follow the PEP8 naming conventions.
2. Use single quotes, instead of double quotes to take up less space visually.
3. Import only the necessary methods and classes instead of importing the entire library.
4. Change the methods to properties to make their use more comfortable.
5. Simplify and refactorize code to make it more compact.