### PR TITLE
Set similar message to help default message

### DIFF
--- a/cuba_weather/weather.py
+++ b/cuba_weather/weather.py
@@ -41,12 +41,12 @@ class RCApiClient:
 
 def main():
     parser = ArgumentParser()
-    parser.add_argument('location', type=str, help='Location name')
-    parser.add_argument('-v', '--version', help='Shows program version', action='store_true')
-    parser.add_argument('-t', '--temperature', help='Shows location temperature', action='store_true')
-    parser.add_argument('-u', '--humidity', help='Shows location humidity', action='store_true')
-    parser.add_argument('-p', '--pressure', help='Shows location pressure', action='store_true')
-    parser.add_argument('-g', '--general', help='Shows location general information', action='store_true')
+    parser.add_argument('location', type=str, help='location name')
+    parser.add_argument('-v', '--version', help='show program version', action='store_true')
+    parser.add_argument('-t', '--temperature', help='show location temperature', action='store_true')
+    parser.add_argument('-u', '--humidity', help='show location humidity', action='store_true')
+    parser.add_argument('-p', '--pressure', help='show location pressure', action='store_true')
+    parser.add_argument('-g', '--general', help='show location general information', action='store_true')
 
     args = parser.parse_args()
 

--- a/cuba_weather/weather.py
+++ b/cuba_weather/weather.py
@@ -6,7 +6,7 @@ from urllib.error import HTTPError
 from urllib.parse import quote
 from urllib.request import urlopen
 
-__version__ = '0.0.3'
+__version__ = '0.0.4'
 
 API = 'https://www.redcuba.cu/api/weather_get_summary/{location}'
 


### PR DESCRIPTION
Since the default help message is `show this help message and exit`, then the other method messages should be similar.